### PR TITLE
CER-1969 Add Option To Only Display Failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,18 +97,96 @@ Filename for html report.
 
 <pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
    savePath: './test/reports/',
-   filePrefix: 'index'
+   fileNamePrefix: 'Prefix'
 }));</code></pre>
 
-Default is <code>htmlReport.html</code>
+Default is <code>nothing</code>
 
 ### Consolidate and ConsolidateAll (optional)
 
-This option allow you to create different HTML for each test suite.
+This option allow you to create a single file for each reporter.
 
 <pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
-   consolidate: true,
-   consolidateAll: true
+   consolidate: false,
+   consolidateAll: false
+}));</code></pre>
+
+Default is <code>true</code>
+
+### CleanDestination (optional)
+
+This option, if false, will not delete the reports or screenshots before each test run. 
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   savePath: './test/reports/',
+   cleanDestination: false
+}));</code></pre>
+
+Default is <code>true</code>
+
+### showPassed (optional)
+
+This option, if false, will show only failures. 
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   ....
+   showPassed: false
+}));</code></pre>
+
+Default is <code>true</code>
+
+### fileName (optional)
+
+This will be the name used for the html file generated thanks to this tool.
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   ....
+   fileName: 'MyReportName'
+}));</code></pre>
+
+Default is <code>htmlReport</code>
+
+### fileNameSeparator (optional)
+
+This will set the separator between filename elements, for example, prefix, sufix etc.
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   ....
+   fileNameSeparator: '_'
+}));</code></pre>
+
+Default is <code>-</code>
+
+### fileNamePrefix (optional)
+
+Prefix used before the name of the report
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   ....
+   fileNamePrefix: ''
+}));</code></pre>
+
+Default is <code>empty</code>
+
+### fileNameSuffix (optional)
+
+Suffix used after the name of the report
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   ....
+   fileNameSuffix: ''
+}));</code></pre>
+
+Default is <code>empty</code>
+
+### fileNameDateSuffix (optional)
+
+Datetime information to be added in the name of the report. This will be placed after the fileNameSuffix if it exists.
+The format is: YYYYMMDD HHMMSS,MILL -> 20161230 133323,728
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   ....
+   fileNameDateSuffix: true
 }));</code></pre>
 
 Default is <code>false</code>

--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ This option, if false, will show only failures.
 
 Default is <code>true</code>
 
+### showFailuresOnly (optional)
+This option if true will hide all passed tests and only display the failures.
+
+<pre><code>jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+   ....
+   showFailuresOnly: true
+}));</code></pre>
+
+Default is <code>false</code>
+
+*NB* If you are using protractor flake, this will show passed tests if they passed on the second run but failed on the first.
+
 ### fileName (optional)
 
 This will be the name used for the html file generated thanks to this tool.

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ function Jasmine2HTMLReporter(options) {
     self.fileName = options.fileName === UNDEFINED ? 'htmlReport' : options.fileName;
     self.cleanDestination = options.cleanDestination === UNDEFINED ? true : options.cleanDestination;
     self.showPassed = options.showPassed === UNDEFINED ? true : options.showPassed;
-    self.showFailuresOnly = options.showFailuresOnly === UNDEFINED ? true : options.showFailuresOnly;
+    self.showFailuresOnly = options.showFailuresOnly === UNDEFINED ? false : options.showFailuresOnly;
 
     var suites = [],
         flakes = [],

--- a/index.js
+++ b/index.js
@@ -72,8 +72,10 @@ function rmdir(dir) {
 }
 
 function getReportDate() {
-    if (reportDate === undefined)
+    if (_.isUndefined(reportDate)) {
         reportDate = new Date();
+    }
+
     return reportDate.getFullYear() + '' +
         (reportDate.getMonth() + 1) +
         reportDate.getDate() + ' ' +
@@ -140,19 +142,23 @@ function Jasmine2HTMLReporter(options) {
 
     function getReportFilename(specName) {
         var name = '';
-        if (self.fileNamePrefix)
+        if (self.fileNamePrefix) {
             name += self.fileNamePrefix + self.fileNameSeparator;
+        }
 
         name += self.fileName;
 
-        if (specName !== undefined)
+        if (_.isUndefined(specName)) {
             name += self.fileNameSeparator + specName;
+        }
 
-        if (self.fileNameSuffix)
+        if (self.fileNameSuffix) {
             name += self.fileNameSeparator + self.fileNameSuffix;
+        }
 
-        if (self.fileNameDateSuffix)
+        if (self.fileNameDateSuffix) {
             name += self.fileNameSeparator + getReportDate();
+        }
 
         return name;
     }
@@ -176,8 +182,9 @@ function Jasmine2HTMLReporter(options) {
      * Persist failed suite names to node local storage
      */
     function saveFlakedSuiteNames() {
-        if (Object.keys(flakedSuiteNames).length === 0)
-            return
+        if (_.isEmpty(Object.keys(flakedSuiteNames))) {
+            return;
+        }
 
         var storedNames = loadFlakedSuiteNames();
         namesToBeStored = Object.assign(storedNames, flakedSuiteNames);
@@ -192,8 +199,12 @@ function Jasmine2HTMLReporter(options) {
     function loadFlakedSuiteNames() {
         var storedSuiteNames = storage.getItem(storageUID) || {};
 
-        if (typeof storedSuiteNames === 'string') {
-            return JSON.parse(storedSuiteNames);
+        if (_.isString(storedSuiteNames)) {
+            try {
+                return JSON.parse(storedSuiteNames);
+            } catch (error) {
+                log('Error retrieving flaked suite names', error);
+            }
         }
 
         return storedSuiteNames;
@@ -216,7 +227,7 @@ function Jasmine2HTMLReporter(options) {
         var suiteName = getFullyQualifiedSuiteName(suite);
 
         if (flakedSuiteNames[suiteName] && flakedSuiteNames[suiteName].length > 0) {
-            return true
+            return true;
         }
 
         return false;

--- a/index.js
+++ b/index.js
@@ -165,10 +165,6 @@ function Jasmine2HTMLReporter(options) {
             return !isPassed(spec) || (flakedSuiteNames[suiteName] || []).indexOf(spec.id) > -1;
         });
 
-        for (var i = 0; i < suite._suites.length; i++) {
-            filterOutPassedSpecs(suite._suites[i]);
-        }
-
         return suite;
     }
 
@@ -208,6 +204,7 @@ function Jasmine2HTMLReporter(options) {
 
     function appendFlakeySuite(suite) {
         var suiteCopy = Object.assign({}, suite);
+        suiteCopy._suites = [];
 
         if(!isFlakedSuiteRerun(suite)) {
             let failedSpecIds = suiteCopy._specs

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var fs = require('fs'),
 
 require('string.prototype.startswith');
 
-var storage = new LocalStorage('./scratch');
 var UNDEFINED, exportObject = exports, reportDate;
 
 function sanitizeFilename(name) {
@@ -124,6 +123,9 @@ function Jasmine2HTMLReporter(options) {
             description: 'focused specs',
             fullName: 'focused specs'
         };
+    
+    var storage = new LocalStorage(self.savePath + 'temp');
+    var storageUID = getReportFilename();
 
     var __suites = {}, __specs = {};
     function getSuite(suite) {
@@ -175,11 +177,11 @@ function Jasmine2HTMLReporter(options) {
         var storedNames = loadFlakedSuiteNames();
         namesToBeStored = Object.assign(storedNames, flakedSuiteNames);
 
-        storage.setItem('flakedSuiteNames', JSON.stringify(namesToBeStored));
+        storage.setItem(storageUID, JSON.stringify(namesToBeStored));
     }
 
     function loadFlakedSuiteNames() {
-        var storedSuiteNames = storage.getItem('flakedSuiteNames') || {};
+        var storedSuiteNames = storage.getItem(storageUID) || {};
 
         if (typeof storedSuiteNames === 'string') {
             return JSON.parse(storedSuiteNames);

--- a/index.js
+++ b/index.js
@@ -1,25 +1,27 @@
-var fs     = require('fs'),
+var fs = require('fs'),
     mkdirp = require('mkdirp'),
-    _      = require('lodash'),
-    path   = require('path'),
-    async  = require('async'),
-    hat    = require('hat');
+    _ = require('lodash'),
+    path = require('path'),
+    async = require('async'),
+    hat = require('hat'),
+    LocalStorage = require('node-localstorage').LocalStorage;
 
 require('string.prototype.startswith');
 
+var storage = new LocalStorage('./scratch');
 var UNDEFINED, exportObject = exports, reportDate;
 
-function sanitizeFilename(name){
+function sanitizeFilename(name) {
     name = name.replace(/\s+/gi, '-'); // Replace white space with dash
     return name.replace(/[^a-zA-Z0-9\-]/gi, ''); // Strip any special charactere
 }
-function trim(str) { return str.replace(/^\s+/, "" ).replace(/\s+$/, "" ); }
-function elapsed(start, end) { return (end - start)/1000; }
+function trim(str) { return str.replace(/^\s+/, "").replace(/\s+$/, ""); }
+function elapsed(start, end) { return (end - start) / 1000; }
 function isFailed(obj) { return obj.status === "failed"; }
 function isSkipped(obj) { return obj.status === "pending"; }
 function isDisabled(obj) { return obj.status === "disabled"; }
-function parseDecimalRoundAndFixed(num,dec){
-    var d =  Math.pow(10,dec);
+function parseDecimalRoundAndFixed(num, dec) {
+    var d = Math.pow(10, dec);
     return isNaN((Math.round(num * d) / d).toFixed(dec)) === true ? 0 : (Math.round(num * d) / d).toFixed(dec);
 }
 function extend(dupe, obj) { // performs a shallow copy of all props of `obj` onto `dupe`
@@ -66,19 +68,19 @@ function rmdir(dir) {
             }
         }
         fs.rmdirSync(dir);
-    }catch (e) { log("problem trying to remove a folder:" + dir); }
+    } catch (e) { log("problem trying to remove a folder:" + dir); }
 }
 
-function getReportDate(){
+function getReportDate() {
     if (reportDate === undefined)
         reportDate = new Date();
     return reportDate.getFullYear() + '' +
-            (reportDate.getMonth() + 1) +
-            reportDate.getDate() + ' ' +
-            reportDate.getHours() + '' +
-            reportDate.getMinutes() + '' +
-            reportDate.getSeconds() + ',' +
-            reportDate.getMilliseconds();
+        (reportDate.getMonth() + 1) +
+        reportDate.getDate() + ' ' +
+        reportDate.getHours() + '' +
+        reportDate.getMinutes() + '' +
+        reportDate.getSeconds() + ',' +
+        reportDate.getMilliseconds();
 }
 
 
@@ -111,6 +113,7 @@ function Jasmine2HTMLReporter(options) {
 
     var suites = [],
         flakes = [],
+        flakedSuiteNames = [];
         currentSuite = null,
         totalSpecsExecuted = 0,
         totalSpecsDefined,
@@ -131,7 +134,7 @@ function Jasmine2HTMLReporter(options) {
         return __specs[spec.id];
     }
 
-    function getReportFilename(specName){
+    function getReportFilename(specName) {
         var name = '';
         if (self.fileNamePrefix)
             name += self.fileNamePrefix + self.fileNameSeparator;
@@ -156,7 +159,7 @@ function Jasmine2HTMLReporter(options) {
      */
     function filterOutPassedSpecs(suite) {
         for (var i = 0; i < suite._specs.length; i++) {
-            if ( !(isFailed(suite._specs[i])) ) {
+            if (!(isFailed(suite._specs[i]))) {
                 suite._specs.splice(i, 1);
             }
         }
@@ -168,7 +171,42 @@ function Jasmine2HTMLReporter(options) {
         return suite;
     }
 
-    self.jasmineStarted = function(summary) {
+    function saveFlakedSuiteNames() {
+        storage.setItem('flakedSuiteNames', flakedSuiteNames);
+    }
+
+    function loadFlakedSuiteNames() {
+        return flakedSuiteNames = storage.getItem('flakedSuiteNames');
+    }
+
+    function isFlakeySuite(suite) {
+        return suite._failures > 0;
+    }
+
+    function isFlakedSuiteRerun(suite) {
+        var suiteName = getFullyQualifiedSuiteName(suite);
+
+        if (flakedSuiteNames.indexOf(suiteName) > -1) {
+            return true
+        }
+
+        return false;
+    }
+
+    function appendFlakeySuite(suite) {
+        var suiteCopy = Object.assign({}, suite);
+
+        if(!isFlakedSuiteRerun(suite)) {
+            suiteCopy = filterOutPassedSpecs(suiteCopy);
+            flakedSuiteNames.push(getFullyQualifiedSuiteName(suite));
+        }
+
+        flakes.push(suiteCopy);
+    }
+
+    self.jasmineStarted = function (summary) {
+        loadFlakedSuiteNames();
+
         totalSpecsDefined = summary && summary.totalSpecsDefined || NaN;
         exportObject.startTime = new Date();
         self.started = true;
@@ -182,7 +220,7 @@ function Jasmine2HTMLReporter(options) {
             rmdir(self.savePath);
 
     };
-    self.suiteStarted = function(suite) {
+    self.suiteStarted = function (suite) {
         suite = getSuite(suite);
         suite._startTime = new Date();
         suite._specs = [];
@@ -198,7 +236,7 @@ function Jasmine2HTMLReporter(options) {
         }
         currentSuite = suite;
     };
-    self.specStarted = function(spec) {
+    self.specStarted = function (spec) {
         if (!currentSuite) {
             // focused spec (fit) -- suiteStarted was never called
             self.suiteStarted(fakeFocusedSuite);
@@ -209,7 +247,7 @@ function Jasmine2HTMLReporter(options) {
         currentSuite._specs.push(spec);
     };
 
-    self.specDone = function(spec) {
+    self.specDone = function (spec) {
         spec = getSpec(spec);
         spec._endTime = new Date();
         if (isSkipped(spec)) { spec._suite._skipped++; }
@@ -243,7 +281,7 @@ function Jasmine2HTMLReporter(options) {
 
 
     };
-    self.suiteDone = function(suite) {
+    self.suiteDone = function (suite) {
         suite = getSuite(suite);
 
         if (suite._parent === UNDEFINED) {
@@ -253,18 +291,19 @@ function Jasmine2HTMLReporter(options) {
         suite._endTime = new Date();
         currentSuite = suite._parent;
 
-        if (suite._failures > 0) {
-            suiteCopy = Object.assign({}, suite);
-            suiteCopy = filterOutPassedSpecs(suiteCopy);
-            flakes.push(suiteCopy);
+        if (isFlakedSuiteRerun(suite) || isFlakeySuite(suite)) {
+            appendFlakeySuite(suite);
         }
     };
 
-    self.jasmineDone = function() {
+    self.jasmineDone = function () {
         if (currentSuite) {
             // focused spec (fit) -- suiteDone was never called
             self.suiteDone(fakeFocusedSuite);
         }
+
+        // add suite names to storage for to be loaded in the next jasmine run.
+        saveFlakedSuiteNames();
 
         var outputSuites = self.showFailuresOnly ? flakes : suites;
 
@@ -283,7 +322,7 @@ function Jasmine2HTMLReporter(options) {
         exportObject.endTime = new Date();
     };
 
-    self.getOrWriteNestedOutput = function(suite) {
+    self.getOrWriteNestedOutput = function (suite) {
         var output = suiteAsHtml(suite);
         for (var i = 0; i < suite._suites.length; i++) {
             output += self.getOrWriteNestedOutput(suite._suites[i]);
@@ -352,17 +391,17 @@ function Jasmine2HTMLReporter(options) {
             var spec = suite._specs[i];
             html += '<div class="spec">';
             html += specAsHtml(spec);
-                html += '<div class="resume">';
-                if (spec.screenshot !== UNDEFINED){
-                    html += '<a href="' + self.screenshotsFolder + spec.screenshot + '">';
-                    html += '<img src="' + self.screenshotsFolder + spec.screenshot + '" width="100" height="100" />';
-                    html += '</a>';
-                }
-                html += '<br />';
-                var num_tests= spec.failedExpectations.length + spec.passedExpectations.length;
-                var percentage = (spec.passedExpectations.length*100)/num_tests;
-                html += '<span>Tests passed: ' + parseDecimalRoundAndFixed(percentage,2) + '%</span><br /><progress max="100" value="' + Math.round(percentage) + '"></progress>';
-                html += '</div>';
+            html += '<div class="resume">';
+            if (spec.screenshot !== UNDEFINED) {
+                html += '<a href="' + self.screenshotsFolder + spec.screenshot + '">';
+                html += '<img src="' + self.screenshotsFolder + spec.screenshot + '" width="100" height="100" />';
+                html += '</a>';
+            }
+            html += '<br />';
+            var num_tests = spec.failedExpectations.length + spec.passedExpectations.length;
+            var percentage = (spec.passedExpectations.length * 100) / num_tests;
+            html += '<span>Tests passed: ' + parseDecimalRoundAndFixed(percentage, 2) + '%</span><br /><progress max="100" value="' + Math.round(percentage) + '"></progress>';
+            html += '</div>';
             html += '</div>';
         }
         html += '\n </article>';
@@ -373,15 +412,15 @@ function Jasmine2HTMLReporter(options) {
         var html = '<div class="description">';
         html += '<h3>' + escapeInvalidHtmlChars(spec.description) + ' - ' + elapsed(spec._startTime, spec._endTime) + 's</h3>';
 
-        if (spec.failedExpectations.length > 0 || spec.passedExpectations.length > 0 ){
+        if (spec.failedExpectations.length > 0 || spec.passedExpectations.length > 0) {
             html += '<ul>';
-            _.each(spec.failedExpectations, function(expectation){
+            _.each(spec.failedExpectations, function (expectation) {
                 html += '<li>';
                 html += expectation.message + '<span style="padding:0 1em;color:red;">&#10007;</span>';
                 html += '</li>';
             });
-            if(self.showPassed === true){
-                _.each(spec.passedExpectations, function(expectation){
+            if (self.showPassed === true) {
+                _.each(spec.passedExpectations, function (expectation) {
                     html += '<li>';
                     html += expectation.message + '<span style="padding:0 1em;color:green;">&#10003;</span>';
                     html += '</li>';
@@ -389,23 +428,23 @@ function Jasmine2HTMLReporter(options) {
             }
             html += '</ul></div>';
         }
-        else{
+        else {
             html += '<span style="padding:0 1em;color:orange;">***Skipped***</span>';
             html += '</div>';
         }
         return html;
     }
 
-    self.writeFile = function(filename, text) {
+    self.writeFile = function (filename, text) {
         var errors = [];
         var path = self.savePath;
 
-        function appendwrite(path, filename, text){
+        function appendwrite(path, filename, text) {
             var fs = require("fs");
             var nodejs_path = require("path");
             require("mkdirp").sync(path); // make sure the path exists
             var filepath = nodejs_path.join(path, filename);
-            fs.appendFileSync(filepath,text);
+            fs.appendFileSync(filepath, text);
             return;
         }
 
@@ -447,7 +486,7 @@ function Jasmine2HTMLReporter(options) {
 
     // To remove complexity and be more DRY about the silly preamble and <testsuites> element
     var prefix = '<!DOCTYPE html><html><head lang=en><meta charset=UTF-8><title>Test Report -  ' + getReportDate() + '</title><style>body{font-family:"open_sans",sans-serif}.suite{width:100%;overflow:auto}.suite .stats{margin:0;width:90%;padding:0}.suite .stats li{display:inline;list-style-type:none;padding-right:20px}.suite h2{margin:0}.suite header{margin:0;padding:5px 0 5px 5px;background:#003d57;color:white}.spec{width:100%;overflow:auto;border-bottom:1px solid #e5e5e5}.spec:hover{background:#e8f3fb}.spec h3{margin:5px 0}.spec .description{margin:1% 2%;width:65%;float:left}.spec .resume{width:29%;margin:1%;float:left;text-align:center}</style></head>';
-        prefix += '<body><section>';
+    prefix += '<body><section>';
     var suffix = '\n</section></body></html>';
 
     function wrapOutputAndWriteFile(filename, text) {

--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ function Jasmine2HTMLReporter(options) {
             }
         }
 
-        return storedSuiteNames;
+        return {};
     }
     
     /**
@@ -241,7 +241,7 @@ function Jasmine2HTMLReporter(options) {
         var suiteCopy = Object.assign({}, suite);
         suiteCopy._suites = [];
 
-        // if it is suite's first run remove all passed specs and save failing specs.
+        // if it is suite's first run remove all passed specs and save failing spec ids.
         if(!isFlakedSuiteRerun(suite)) {
             let failedSpecIds = suiteCopy._specs
                 .filter((spec) => !isPassed(spec))

--- a/index.js
+++ b/index.js
@@ -266,9 +266,9 @@ function Jasmine2HTMLReporter(options) {
             rmdir(self.savePath);
         }
         //Delete previous reports unless cleanDirectory is false
-        if (self.cleanDestination)
+        if (self.cleanDestination) {
             rmdir(self.savePath);
-
+        }
     };
     self.suiteStarted = function (suite) {
         suite = getSuite(suite);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "hat": "^0.0.3",
     "lodash": "^4.17.0",
     "mkdirp": "^0.5.0",
-    "node-persist": "^3.0.5",
+    "node-localstorage": "^2.1.5",
     "string.prototype.startswith": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "hat": "^0.0.3",
     "lodash": "^4.17.0",
     "mkdirp": "^0.5.0",
+    "node-persist": "^3.0.5",
     "string.prototype.startswith": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,39 +1,47 @@
 {
   "name": "protractor-jasmine2-html-reporter",
-  "version": "0.0.6",
-  "description": "HTML reporter for Jasmine2 and Protractor",
+  "version": "0.0.7",
+  "description": "HTML reporter for Jasmine and Protractor. It will generate beautiful and useful report for your web apps.",
   "main": "index.js",
   "scripts": {
     "test": "protractor protractor.config.js"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Kenzitron/protractor-jasmine2-html-reporter"
+    "url": "https://github.com/Kenzitron/protractor-jasmine2-html-reporter",
+    "postinstall": "./node_modules/protractor/bin/webdriver-manager update"
   },
   "keywords": [
-    "jasmine2",
+    "jasmine",
+    "jasmine 2",
     "protractor",
     "reporter",
     "html",
     "test",
     "functional testing",
-    "screenshots",
+    "screenshot",
     "end2end",
     "bdd"
   ],
   "author": "Alejandro Asensio <alejandro@kenzilab.com> (http://www.kenzilab.com/)",
+  "contributors": [
+    "Calin Fraser <calinfraser@gmail.com> (https://github.com/kaliayev)",
+    "Vasanth K <vasanth.k@perfomatix.com> (https://github.com/vasanth5738)",
+    "Chris Rudmin (https://github.com/chris-rudmin)"
+  ],
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/Kenzitron/protractor-jasmine2-html-reporter/issues"
   },
   "dependencies": {
-    "hat": "0.0.3",
-    "lodash": "^4.0.0",
+    "async": "^2.1.4",
+    "hat": "^0.0.3",
+    "lodash": "^4.17.0",
     "mkdirp": "^0.5.0",
     "string.prototype.startswith": "^0.2.0"
   },
   "devDependencies": {
-    "jasmine": "^2.4.1",
-    "protractor": "^3.1.1"
+    "jasmine": "^2.5.2",
+    "phantomjs": "^2.1.7"
   }
 }

--- a/protractor.config.js
+++ b/protractor.config.js
@@ -3,21 +3,24 @@ exports.config = {
 
     // Capabilities to be passed to the webdriver instance.
     capabilities: {
-        'browserName': 'chrome'
+        'browserName': 'phantomjs'
     },
     framework: 'jasmine2',
 
-    directConnect: true,
+    //directConnect: true,
 
     specs: ['test/**/*[sS]pec.js'],
 
     onPrepare: function() {
 
-        var Jasmine2HtmlReporter = require('./index.js');
+        return global.browser.getProcessedConfig().then(function (config) {
+            var Jasmine2HtmlReporter = require('./index.js');
 
-        jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
-            savePath: './test/reports/'
-        }));
+            jasmine.getEnv().addReporter(new Jasmine2HtmlReporter({
+                savePath: './test/reports/'
+            }));
+        });
+
 
     }
 };

--- a/test/test3Spec.js
+++ b/test/test3Spec.js
@@ -1,0 +1,29 @@
+xdescribe('SPEC 3', function() {
+
+    it('3 should add a todo', function() {
+        browser.get('http://www.angularjs.org');
+
+        element(by.model('todoList.todoText')).sendKeys('write a protractor test');
+        element(by.css('[value="add"]')).click();
+
+        var todoList = element.all(by.repeater('todo in todoList.todos'));
+        expect(todoList.count()).toEqual(3);
+        expect(todoList.count()).toEqual(6); //Failure
+        expect(todoList.get(2).getText()).toEqual('write a protractor test');
+    });
+
+    it('3 second it', function() {
+        browser.get('http://www.angularjs.org');
+
+        element(by.model('todoList.todoText')).sendKeys('write a protractor test');
+        element(by.css('[value="add"]')).click();
+
+        var todoList = element.all(by.repeater('todo in todoList.todos'));
+        expect(todoList.count()).toEqual(3);
+        expect(todoList.count()).toEqual(3);
+        expect(todoList.count()).toEqual(3);
+        expect(todoList.count()).toEqual(3);
+        expect(todoList.get(2).getText()).toEqual('write a protractor test');
+    });
+
+});


### PR DESCRIPTION
### What this pull request does.
This html reporter lacks the ability to hide all passed tests and only display failed tests. This pull request adds this ability. It also supports doing this for tests ran a second time by protractor flake.

It uses a suites fully qualified name (the name of a suite concatenated to the name of all its parent suites) to determine if the suite is a rerun.

It also updates or fork with changes from the original repo https://github.com/Kenzitron/protractor-jasmine2-html-reporter master branch.

**NOTE**: Main otto pull request in ceros-product that uses this feature is here: https://github.com/ceros/ceros-product/pull/6359 .

### Gotchas
- This change assumes that suite's fully qualified name is unique.
- It uses node-localstorage to persist failed suite names considering new reporter instance is used for every file run.